### PR TITLE
Shellscript housekeeping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH=aarch64
 ARG VERSION=12.8.0
 ARG UBUNTU_VERSION=24.04
-ARG REPO=axisecp
+ARG REPO=docker.io/axisecp
 ARG SDK=acap-native-sdk
 
 #-------------------------------------------------------------------------------

--- a/build.sh
+++ b/build.sh
@@ -1,35 +1,37 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 # Usage: ./build.sh [--clean]
 # --clean: Force rebuild without cache (slower but ensures fresh build)
 # default: Use cache (faster, TensorFlow only downloaded once)
 
-CACHE_FLAG=""
-if [ "$1" = "--clean" ]; then
-    CACHE_FLAG="--no-cache"
-    echo "Clean build (no cache) - TensorFlow will be downloaded"
+# Use docker if CRUNTIME is not set to something else (e.g. 'podman')
+CRUNTIME=${CRUNTIME:-docker}
+CACHE_FLAG=''
+if [ "${1:-}" = '--clean' ]; then
+	CACHE_FLAG='--no-cache'
+	echo 'Clean build (no cache) - TensorFlow will be downloaded'
 else
-    echo "Cached build - reusing TensorFlow layer"
+	echo 'Cached build - reusing TensorFlow layer'
 fi
 
-echo ""
-echo "=== Building Docker image ==="
-docker build --progress=plain $CACHE_FLAG --build-arg CHIP=aarch64 . -t detectx
+echo '
+=== Building Container image ==='
+$CRUNTIME build --progress=plain $CACHE_FLAG --build-arg CHIP=aarch64 . -t detectx
 
-echo ""
-echo "=== Extracting .eap file from container ==="
-CONTAINER_ID=$(docker create detectx)
-docker cp $CONTAINER_ID:/opt/app ./build
-docker rm $CONTAINER_ID
+echo '
+=== Extracting .eap file from container ==='
+CONTAINER_ID=$($CRUNTIME create detectx)
+$CRUNTIME cp "$CONTAINER_ID":/opt/app ./build
+$CRUNTIME rm "$CONTAINER_ID"
 
-echo ""
-echo "=== Copying .eap file to current directory ==="
+echo '
+=== Copying .eap file to current directory ==='
 cp -v ./build/*.eap .
 
-echo ""
-echo "=== Cleaning up build directory ==="
+echo '
+=== Cleaning up build directory ==='
 rm -rf ./build
 
-echo ""
-echo "=== Build complete ==="
-ls -lh *.eap
+echo '
+=== Build complete ==='
+ls -lh ./*.eap

--- a/clean_install.sh
+++ b/clean_install.sh
@@ -1,65 +1,65 @@
-#!/bin/bash
+#!/bin/sh -eu
 # Clean installation script for DetectX
 # Run this script on the camera via SSH
 
-echo "========================================="
-echo "DetectX Clean Installation Script"
-echo "========================================="
+echo '=========================================
+DetectX Clean Installation Script
+========================================='
 
 # Stop the application
-echo ""
-echo "1. Stopping detectx application..."
+echo '
+1. Stopping detectx application...'
 systemctl stop detectx 2>/dev/null || true
 
 # Check if package exists
-if [ -d "/usr/local/packages/detectx" ]; then
-    echo ""
-    echo "2. Found existing installation. Checking HTML file..."
+if [ -d '/usr/local/packages/detectx' ]; then
+	echo '
+2. Found existing installation. Checking HTML file...'
 
-    # Check current transparency value
-    if [ -f "/usr/local/packages/detectx/html/index.html" ]; then
-        echo "   Current transparency value:"
-        grep "rgba(0, 0, 0," /usr/local/packages/detectx/html/index.html | grep "fillStyle" | head -1
+	# Check current transparency value
+	if [ -f '/usr/local/packages/detectx/html/index.html' ]; then
+		echo '   Current transparency value:'
+		grep 'rgba(0, 0, 0,' /usr/local/packages/detectx/html/index.html | grep fillStyle | head -1
 
-        echo "   Current card width:"
-        grep "control-row mt-4" /usr/local/packages/detectx/html/index.html
-    fi
+		echo '   Current card width:'
+		grep 'control-row mt-4' /usr/local/packages/detectx/html/index.html
+	fi
 
-    # Complete removal
-    echo ""
-    echo "3. Completely removing old installation..."
-    rm -rf /usr/local/packages/detectx
+	# Complete removal
+	echo '
+3. Completely removing old installation...'
+	rm -rf /usr/local/packages/detectx
 
-    # Verify removal
-    if [ -d "/usr/local/packages/detectx" ]; then
-        echo "   ERROR: Failed to remove old installation!"
-        exit 1
-    else
-        echo "   Successfully removed old installation"
-    fi
+	# Verify removal
+	if [ -d '/usr/local/packages/detectx' ]; then
+		echo '   ERROR: Failed to remove old installation!' >&2
+		exit 1
+	else
+		echo '   Successfully removed old installation'
+	fi
 else
-    echo ""
-    echo "2. No existing installation found"
+	echo '
+2. No existing installation found'
 fi
 
 # Install new version
-echo ""
-echo "4. Installing new version..."
-if [ ! -f "/tmp/DetectX_COCO_3_6_0_aarch64.eap" ]; then
-    echo "   ERROR: /tmp/DetectX_COCO_3_6_0_aarch64.eap not found!"
-    echo "   Please copy the .eap file to /tmp first:"
-    echo "   scp DetectX_COCO_3_6_0_aarch64.eap root@<camera-ip>:/tmp/"
-    exit 1
+echo '
+4. Installing new version...'
+if [ ! -f '/tmp/DetectX_COCO_3_6_0_aarch64.eap' ]; then
+	echo '   ERROR: /tmp/DetectX_COCO_3_6_0_aarch64.eap not found!
+Please copy the .eap file to /tmp first:
+scp DetectX_COCO_3_6_0_aarch64.eap root@<camera-ip>:/tmp/' >&2
+	exit 1
 fi
 
 cd /tmp
 gunzip -c DetectX_COCO_3_6_0_aarch64.eap | tar -xf -
 
 # Find and run the install script
-INSTALL_SCRIPT=$(ls -1 detectx_*.sh 2>/dev/null | head -1)
+INSTALL_SCRIPT=$(find . -maxdepth 1 -name 'detectx_*.sh' -print -quit 2>/dev/null)
 if [ -z "$INSTALL_SCRIPT" ]; then
-    echo "   ERROR: Install script not found!"
-    exit 1
+	echo '   ERROR: Install script not found!' >&2
+	exit 1
 fi
 
 echo "   Running $INSTALL_SCRIPT..."
@@ -67,55 +67,55 @@ chmod +x "$INSTALL_SCRIPT"
 ./"$INSTALL_SCRIPT" install
 
 # Verify installation
-echo ""
-echo "5. Verifying new installation..."
-if [ -d "/usr/local/packages/detectx" ]; then
-    echo "   Installation directory exists: OK"
+echo '
+5. Verifying new installation...'
+if [ -d '/usr/local/packages/detectx' ]; then
+	echo '   Installation directory exists: OK'
 
-    if [ -f "/usr/local/packages/detectx/html/index.html" ]; then
-        echo ""
-        echo "   Checking HTML file in installed package:"
-        echo "   Transparency value:"
-        grep "rgba(0, 0, 0," /usr/local/packages/detectx/html/index.html | grep "fillStyle" | head -1
+	if [ -f '/usr/local/packages/detectx/html/index.html' ]; then
+		echo '
+   Checking HTML file in installed package:
+   Transparency value:'
+		grep 'rgba(0, 0, 0,' /usr/local/packages/detectx/html/index.html | grep fillStyle | head -1
 
-        echo ""
-        echo "   Card width:"
-        grep "control-row mt-4" /usr/local/packages/detectx/html/index.html
+		echo '
+   Card width:'
+		grep 'control-row mt-4' /usr/local/packages/detectx/html/index.html
 
-        echo ""
-        echo "   Scale mode options:"
-        grep -A2 "settings_scaleMode" /usr/local/packages/detectx/html/index.html | grep "option value"
-    else
-        echo "   ERROR: index.html not found in installation!"
-        exit 1
-    fi
+		echo '
+   Scale mode options:'
+		grep -A2 settings_scaleMode /usr/local/packages/detectx/html/index.html | grep 'option value'
+	else
+		echo '   ERROR: index.html not found in installation!' >&2
+		exit 1
+	fi
 else
-    echo "   ERROR: Installation failed!"
-    exit 1
+	echo '   ERROR: Installation failed!' >&2
+	exit 1
 fi
 
 # Start the application
-echo ""
-echo "6. Starting detectx application..."
+echo '
+6. Starting detectx application...'
 systemctl start detectx
 
 # Wait a moment
 sleep 2
 
 # Check status
-echo ""
-echo "7. Application status:"
+echo '
+7. Application status:'
 systemctl status detectx --no-pager | head -10
 
-echo ""
-echo "========================================="
-echo "Installation complete!"
-echo "========================================="
-echo ""
-echo "IMPORTANT: Clear your browser cache or use incognito mode:"
-echo "  - Firefox: Ctrl+Shift+Delete"
-echo "  - Chromium: Ctrl+Shift+Delete"
-echo "  - Or open in incognito/private mode"
-echo ""
-echo "Then navigate to: http://<camera-ip>/local/detectx/index.html"
-echo ""
+echo '
+=========================================
+Installation complete!
+=========================================
+
+IMPORTANT: Clear your browser cache or use incognito mode:
+  - Firefox: Ctrl+Shift+Delete
+  - Chromium: Ctrl+Shift+Delete
+  - Or open in incognito/private mode
+
+Then navigate to: http://<camera-ip>/local/detectx/index.html
+'

--- a/exclude_local_changes.sh
+++ b/exclude_local_changes.sh
@@ -1,69 +1,63 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 # Script to exclude specific files from being committed to the repository
 # These files may change locally but should never be committed
 
-set -e
+echo 'Configuring Git to exclude specific files from commits...'
 
-echo "Configuring Git to exclude specific files from commits..."
+# Files and patterns to exclude (space-separated, no whitespace in values)
+FILES_TO_EXCLUDE=".gitignore
+    README.md
+    app/model/model.tflite
+    app/model/labels.txt
+    app/manifest.json"
 
-# Files and patterns to exclude
-FILES_TO_EXCLUDE=(
-    ".gitignore"
-    "README.md"
-    "app/model/model.tflite"
-    "app/model/labels.txt"
-    "app/manifest.json"
-)
-
-PATTERNS_TO_GITIGNORE=(
-    "*.eap"
-    "*.EAP"
-)
+PATTERNS_TO_GITIGNORE="*.eap
+    *.EAP"
 
 # Add patterns to .gitignore if not already present
-echo ""
-echo "Updating .gitignore..."
-for pattern in "${PATTERNS_TO_GITIGNORE[@]}"; do
-    if ! grep -Fxq "$pattern" .gitignore 2>/dev/null; then
-        echo "$pattern" >> .gitignore
-        echo "  Added: $pattern"
-    else
-        echo "  Already in .gitignore: $pattern"
-    fi
+echo '
+Updating .gitignore...'
+for pattern in $PATTERNS_TO_GITIGNORE; do
+	if ! grep -Fxq "$pattern" .gitignore 2>/dev/null; then
+		echo "$pattern" >> .gitignore
+		echo "  Added: $pattern"
+	else
+		echo "  Already in .gitignore: $pattern"
+	fi
 done
 
 # For each specific file, use git update-index --assume-unchanged
-echo ""
-echo "Marking files to be ignored by Git (assume-unchanged)..."
-for file in "${FILES_TO_EXCLUDE[@]}"; do
-    if [ -f "$file" ]; then
-        git update-index --assume-unchanged "$file" 2>/dev/null && \
-            echo "  ✓ Ignoring changes to: $file" || \
-            echo "  ⚠ Could not mark (may not be tracked): $file"
-    else
-        echo "  ⚠ File not found: $file"
-    fi
+echo '
+Marking files to be ignored by Git (assume-unchanged)...'
+for file in $FILES_TO_EXCLUDE; do
+	if [ -f "$file" ]; then
+		git update-index --assume-unchanged "$file" 2>/dev/null && \
+			echo "  ✓ Ignoring changes to: $file" || \
+			echo "  ⚠ Could not mark (may not be tracked): $file"
+	else
+		echo "  ⚠ File not found: $file"
+	fi
 done
 
 # Handle all .eap and .EAP files
-echo ""
-echo "Marking .eap/.EAP files to be ignored..."
+echo '
+Marking .eap/.EAP files to be ignored...'
 for eapfile in *.eap *.EAP; do
-    if [ -f "$eapfile" ]; then
-        git update-index --assume-unchanged "$eapfile" 2>/dev/null && \
-            echo "  ✓ Ignoring changes to: $eapfile" || \
-            echo "  ⚠ Could not mark (may not be tracked): $eapfile"
-    fi
+	if [ -f "$eapfile" ]; then
+		git update-index --assume-unchanged "$eapfile" 2>/dev/null && \
+			echo "  ✓ Ignoring changes to: $eapfile" || \
+			echo "  ⚠ Could not mark (may not be tracked): $eapfile"
+	fi
 done
 
-echo ""
-echo "=========================================="
-echo "Configuration complete!"
-echo ""
-echo "To undo this for a specific file, run:"
-echo "  git update-index --no-assume-unchanged <filename>"
-echo ""
-echo "To see which files are marked as assume-unchanged:"
-echo "  git ls-files -v | grep '^h'"
-echo "=========================================="
+echo '
+==========================================
+Configuration complete!
+
+To undo this for a specific file, run:
+  git update-index --no-assume-unchanged <filename>
+
+To see which files are marked as assume-unchanged:
+  git ls-files -v | grep '"'"'^h'"'"'
+=========================================='

--- a/install.sh
+++ b/install.sh
@@ -1,26 +1,25 @@
-#!/bin/bash
+#!/bin/sh -eu
 #
 # Install DetectX EAP to Axis camera
-#
 
-CAMERA_HOST="${1:-front.internal}"
-USERNAME="nodered"
-PASSWORD="rednode"
+CAMERA_HOST=${1:-front.internal}
+USERNAME=nodered
+PASSWORD=rednode
 
 # Find the first .eap file in the current directory
-EAP_FILE=$(ls -1 *.eap 2>/dev/null | head -n 1)
+EAP_FILE=$(find . -maxdepth 1 -name \*.eap 2>/dev/null | sort | head -n 1)
 
 if [ -z "$EAP_FILE" ]; then
-    echo "ERROR: No .eap file found in the current directory"
-    exit 1
+	echo 'ERROR: No .eap file found in the current directory' >&2
+	exit 1
 fi
 
 echo "Installing $EAP_FILE to $CAMERA_HOST..."
 
 # Upload using curl with digest authentication
 curl --digest -u "$USERNAME:$PASSWORD" \
-    -F "packfil=@$EAP_FILE;type=application/octet-stream" \
-    "http://$CAMERA_HOST/axis-cgi/applications/upload.cgi"
+	-F "packfil=@$EAP_FILE;type=application/octet-stream" \
+	"http://$CAMERA_HOST/axis-cgi/applications/upload.cgi"
 
-echo ""
-echo "Done."
+echo '
+Done.'


### PR DESCRIPTION
- Use /bin/sh instead of bash for better portability
- Add means to easily run build.sh with podman instead of docker
- Use single quotes for static strings
- Output error messages to stderr
- Use single echo call instead of multiple ones in a row
- Use `find` instead of `ls` in some places for better stability
- Add -eu to scripts to fail early and avoid undefined behavior
- Use tabs for indent